### PR TITLE
Fixed order of existential path reduction

### DIFF
--- a/src/standard_library.rs
+++ b/src/standard_library.rs
@@ -230,6 +230,13 @@ pub fn std() -> Vec<Knowledge> {
         // `f{true1} => f`
         Red(constr("f", True1), "f".into()),
 
+        // `∃(and) => true1`
+        Red(app(Ex, And), True1.into()),
+        // `∃(or) => true1`
+        Red(app(Ex, Or), True1.into()),
+        // `∃(fstb) => true1`
+        Red(app(Ex, Fstb), True1.into()),
+
         // `fstb => fst`
         Red(Fstb.into(), Fst.into()),
         // `sndb => snd`
@@ -259,11 +266,6 @@ pub fn std() -> Vec<Knowledge> {
         // `add(pow(cos(x))(\2))(pow(sin(x))(\2)) <=> 1`
         Red(app(app(Add, app(app(Pow, app(Cos, "x")), 2.0)),
                          app(app(Pow, app(Sin, "x")), 2.0)), 1.0.into()),
-
-        // `∃(and) => true1`
-        Red(app(Ex, And), True1.into()),
-        // `∃(or) => true1`
-        Red(app(Ex, Or), True1.into()),
 
         // `and(a)(b) <=> and(b)(a)`
         commutative(And),


### PR DESCRIPTION
Must come before `fstb => fst`, since the existential path `∃fst` is
not well defined.