### PR TITLE
Support `push` and `push_front` with `concat`

### DIFF
--- a/src/standard_library.rs
+++ b/src/standard_library.rs
@@ -165,6 +165,10 @@ pub fn std() -> Vec<Knowledge> {
         Red(app2(PushFront, list_var("x"), ret_var("y")), binop_ret_var("x", "y", PushFront)),
         // `concat(\x)(\y) => [x, y]`
         Red(app2(Concat, ret_var("x"), ret_var("y")), vec2("x", "y")),
+        // `concat(\x)([y..]) => push_front(y)(x)`
+        Red(app2(Concat, ret_var("x"), list_var("y")), app2(PushFront, "y", "x")),
+        // `concat([x..], \y) => push(x)(y)`
+        Red(app2(Concat, list_var("x"), ret_var("y")), app2(Push, "x", "y")),
         // `concat([x..])([y..]) => x ++ y`
         Red(app2(Concat, list_var("x"), list_var("y")), binop_ret_var("x", "y", Concat)),
         // `len(x) => compute::len(x)`


### PR DESCRIPTION
- Added `concat(\x)([y..]) => push_front(y)(x)`
- Added `concat([x..], \y) => push(x)(y)`