### PR TITLE
Added `f([x..]) => f{(: vec)}(x)`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -885,8 +885,8 @@ pub fn vec2<A: Into<Expr>, B: Into<Expr>>(a: A, b: B) -> Expr {List(vec![a.into(
 /// Knowledge about a component-wise operation on vectors.
 pub fn vec_op<S: Into<Symbol>>(s: S) -> Knowledge {
     let s = s.into();
-    Red(app2(s.clone(), head_tail_list("x0", "y0"), head_tail_list("x1", "y1")),
-        app2(Concat, app2(s.clone(), "x0", "x1"), app2(s, "y0", "y1")))
+    Red(app(constr(app(constr(s.clone(), app(Rty, VecType)), "x"), app(Rty, VecType)), "y"),
+        app2(app(VecOp, s), "x", "y"))
 }
 
 /// Knowledge about a concrete binary operation `f(x : \, y : \) => f(x)(y) : \`.

--- a/src/standard_library.rs
+++ b/src/standard_library.rs
@@ -163,20 +163,9 @@ pub fn std() -> Vec<Knowledge> {
         Red(app2(Push, list_var("x"), "y"), binop_ret_var("x", "y", Push)),
         // `push_front([x..], y) => compute::push_front(x, y)`
         Red(app2(PushFront, list_var("x"), "y"), binop_ret_var("x", "y", PushFront)),
-        // `concat(\x)(\y) => [x, y]`
-        Red(app2(Concat, ret_var("x"), ret_var("y")), vec2("x", "y")),
-        // `concat(\x)([y..]) => push_front(y)(x)`
-        Red(app2(Concat, ret_var("x"), list_var("y")), app2(PushFront, "y", "x")),
-        // `concat([x..], \y) => push(x)(y)`
-        Red(app2(Concat, list_var("x"), ret_var("y")), app2(Push, "x", "y")),
-        // `concat([x..])([y..]) => x ++ y`
-        Red(app2(Concat, list_var("x"), list_var("y")), binop_ret_var("x", "y", Concat)),
-        // `concat(x: : \)(y : \) => [x, y]`
-        Red(app2(Concat, ret_type_var("x"), ret_type_var("y")), vec2("x", "y")),
-        // `concat(x : \)([y..]) => push_front(y)(x)`
-        Red(app2(Concat, ret_type_var("x"), list_var("y")), app2(PushFront, "y", "x")),
-        // `concat([x..])(y : \) => push(x)(y)`
-        Red(app2(Concat, list_var("x"), ret_type_var("y")), app2(Push, "x", "y")),
+        // `concat{(: vec)}(x){(: vec)}(y) => x ++ y`
+        Red(app(constr(app(constr(Concat, app(Rty, VecType)), "x"), app(Rty, VecType)),
+                "y"), binop_ret_var("x", "y", Concat)),
         // `len(x) => compute::len(x)`
         Red(app(Len, "x"), unop_ret_var("x", Len)),
 
@@ -334,6 +323,9 @@ pub fn std() -> Vec<Knowledge> {
         // `add(pow(cos(x))(\2))(pow(sin(x))(\2)) <=> 1`
         Red(app2(Add, app2(Pow, app(Cos, "x"), 2.0),
                       app2(Pow, app(Sin, "x"), 2.0)), 1.0.into()),
+
+        // `f([x..]) => f{(: vec)}(x)`
+        Red(app(no_constr("f"), list_var("x")), app(constr("f", app(Rty, VecType)), "x")),
 
         // `not . nand <=> and`.
         Eqv(comp(Not, Nand), And.into()),


### PR DESCRIPTION
- Removed special cases on `concat`
- Changed `vec_op` to use `{(: vec)}`