### PR TITLE
Fixed `(g . f:[arity]1)(a) <=> f:[arity]1[g](g(a))`

### DIFF
--- a/src/standard_library.rs
+++ b/src/standard_library.rs
@@ -705,8 +705,8 @@ pub fn std() -> Vec<Knowledge> {
         Eqv(app(app(comp("g", arity_var("f", 2)), "a"), "b"), app2(path("f", "g"), app("g", "a"), app("g", "b"))),
         // `g . f:[arity]2 <=> f[g] . (g . fst, g . snd)`
         Eqv(comp("g", arity_var("f", 2)), comp(path("f", "g"), (comp("g", Fst), comp("g", Snd)))),
-        // `(g . f:[arity]1)(a) <=> f[g](g(a))`
-        Eqv(app(comp("g", arity_var("f", 1)), "a"), app(path("f", "g"), app("g", "a"))),
+        // `(g . f:[arity]1)(a) <=> f:[arity]1[g](g(a))`
+        Eqv(app(comp("g", arity_var("f", 1)), "a"), app(path(arity_var("f", 1), "g"), app("g", "a"))),
         // `(g, f)(a) <=> (g(a), f(a))`
         Eqv(app(("g", "f"), "a"), (app("g", "a"), app("f", "a")).into()),
         // `f . (g0, g1)(a) <=> (f . (g0, g1))(a)`


### PR DESCRIPTION
Arity must be checked both ways.