### PR TITLE
Fixed `(g . f:[arity]2){_}(a){_}(b) <=> f:[arity]2[g](g(a))(g(b))`

### DIFF
--- a/src/standard_library.rs
+++ b/src/standard_library.rs
@@ -696,9 +696,9 @@ pub fn std() -> Vec<Knowledge> {
             app2(comp("f", constr(constr("g", "x"), "y")), "a", "b")),
         // `(f . g:[arity]1){x}(a) <=> f(g{x}(a))`
         Eqv(app(constr(comp("f", arity_var("g", 1)), "x"), "a"), app("f", app(constr("g", "x"), "a"))),
-        // `(g . f:[arity]2){_}(a){_}(b) <=> f[g](g(a))(g(b))`
+        // `(g . f:[arity]2){_}(a){_}(b) <=> f:[arity]2[g](g(a))(g(b))`
         Eqv(app(constr(app(constr(comp("g", arity_var("f", 2)), Any), "a"), Any), "b"),
-            app(app(path("f", "g"), app("g", "a")), app("g", "b"))),
+            app(app(path(arity_var("f", 2), "g"), app("g", "a")), app("g", "b"))),
         // `(g . f:[arity]1){_}(a) <=> f:[arity]1[g](g(a))`
         Eqv(app(constr(comp("g", arity_var("f", 1)), Any), "a"),
             app(path(arity_var("f", 1), "g"), app("g", "a"))),


### PR DESCRIPTION
Arity must be checked both ways.