### PR TITLE
Fixed `(g . f:[arity]2)(a)(b) <=> f:[arity]2[g](g(a))(g(b))`

### DIFF
--- a/src/standard_library.rs
+++ b/src/standard_library.rs
@@ -702,8 +702,9 @@ pub fn std() -> Vec<Knowledge> {
         // `(g . f:[arity]1){_}(a) <=> f:[arity]1[g](g(a))`
         Eqv(app(constr(comp("g", arity_var("f", 1)), Any), "a"),
             app(path(arity_var("f", 1), "g"), app("g", "a"))),
-        // `(g . f:[arity]2)(a)(b) <=> f[g](g(a))(g(b))`
-        Eqv(app(app(comp("g", arity_var("f", 2)), "a"), "b"), app2(path("f", "g"), app("g", "a"), app("g", "b"))),
+        // `(g . f:[arity]2)(a)(b) <=> f:[arity]2[g](g(a))(g(b))`
+        Eqv(app(app(comp("g", arity_var("f", 2)), "a"), "b"),
+            app2(path(arity_var("f", 2), "g"), app("g", "a"), app("g", "b"))),
         // `g . f:[arity]2 <=> f[g] . (g . fst, g . snd)`
         Eqv(comp("g", arity_var("f", 2)), comp(path("f", "g"), (comp("g", Fst), comp("g", Snd)))),
         // `(g . f:[arity]1)(a) <=> f:[arity]1[g](g(a))`


### PR DESCRIPTION
Arity must be checked both ways.