### PR TITLE
Improved readability of Poi Reduce

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ and[not]
 or
 ∵ and[not] => or
 <=>  not · nor
-∵ not · nor <=> or
+     ∵ not · nor <=> or
+∴ or
 ```
 
 To run Poi Reduce from your Terminal, type:

--- a/examples/poireduce.rs
+++ b/examples/poireduce.rs
@@ -120,8 +120,10 @@ fn main() {
         let equivalences = expr.equivalences(std);
         for i in 0..equivalences.len() {
             let j = equivalences[i].1;
-            println!("<=>  {}\n∵ {}", equivalences[i].0, std[j]);
+            println!("<=>  {}\n     ∵ {}", equivalences[i].0, std[j]);
         }
+        
+        println!("∴ {}", expr);
 
         prev_expr = Some(expr);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,8 @@
 //! or
 //! ∵ and[not] => or
 //! <=>  not · nor
-//! ∵ not · nor <=> or
+//!      ∵ not · nor <=> or
+//! ∴ or
 //! ```
 //!
 //! To run Poi Reduce from your Terminal, type:


### PR DESCRIPTION
- Use spacing to signify the `∵` rules that belong to equivalences
- Added `∴` to the end after equivalences
- Updated example