### PR TITLE
 Added `∀(f:[arity]2{g0}{g1}) => (g0, g1)` 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1066,6 +1066,11 @@ pub fn constr<A: Into<Expr>, B: Into<Expr>>(a: A, b: B) -> Expr {
     Op(Constrain, Box::new(a.into()), Box::new(b.into()))
 }
 
+/// A function domain constraint with two arguments.
+pub fn constr2<A: Into<Expr>, B: Into<Expr>, C: Into<Expr>>(a: A, b: B, c: C) -> Expr {
+    constr(constr(a, b), c)
+}
+
 /// A type judgement.
 pub fn typ<A: Into<Expr>, B: Into<Expr>>(a: A, b: B) -> Expr {
     Op(Type, Box::new(a.into()), Box::new(b.into()))

--- a/src/standard_library.rs
+++ b/src/standard_library.rs
@@ -50,6 +50,8 @@ pub fn std() -> Vec<Knowledge> {
         Red(path("f", ("g", "g")), path("f", "g")),
         // `f[g x g -> g] => f[g]`
         Red(path("f", ("g", "g", "g")), path("f", "g")),
+        // `∀(f:[arity]2{g0}{g1}) => (g0, g1)`
+        Red(app(Triv, constr2(arity_var("f", 2), "g0", "g1")), ("g0", "g1").into()),
         // `∀(f:[arity]1{g}) => g`
         Red(app(Triv, constr(arity_var("f", 1), "g")), "g".into()),
         // `∀(f) => \true`


### PR DESCRIPTION
- Added `constr2`