### PR TITLE
Change edge case of `f{a} . g`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -592,7 +592,7 @@ impl Expr {
                     true
                 }
             }
-            Op(Compose, _, b) => b.has_constraint(arity_level),
+            Op(Compose, a, b) => b.has_constraint(arity_level) || a.has_constraint(1),
             Op(Apply, f, _) => f.has_constraint(arity_level + 1),
             Sym(_) => false,
             _ => true
@@ -1267,7 +1267,7 @@ mod tests {
         assert_eq!(f.has_constraint(1), true);
         // `not{not} . not`
         let f: Expr = comp(constr(Not, Not), Not);
-        assert_eq!(f.has_constraint(1), false);
+        assert_eq!(f.has_constraint(1), true);
         // `not . not{not}`
         let f: Expr = comp(Not, constr(Not, Not));
         assert_eq!(f.has_constraint(1), true);


### PR DESCRIPTION
A domain constraint on the first part `f` of a composition implies a
constraint on the second part `g` if the constraint does not cover the
codomain of `g`. Althought this is not syntactically true, it is safest
to return `true` from `has_constraint`.