### PR TITLE
Improved `((f . g) = h) <=> ((inv(f) . f) . g)) = (inv(f) . h))`

### DIFF
--- a/src/standard_library.rs
+++ b/src/standard_library.rs
@@ -1052,9 +1052,9 @@ pub fn std() -> Vec<Knowledge> {
         Eqv(app(Inv, comp("f", "g")), comp(app(Inv, "g"), app(Inv, "f"))),
         // `id[(f . g) -> id] <=> id[f -> id[g -> id]]`
         Eqv(path(Id, (comp("f", "g"), Id)), path(Id, ("f", path(Id, ("g", Id))))),
-        // `((f . g) = h) <=> (inv(f) . (f . g)) = (inv(f) . h))`
+        // `((f . g) = h) <=> ((inv(f) . f) . g)) = (inv(f) . h))`
         Eqv(app2(Eq, comp("f", "g"), "h"),
-            app2(Eq, comp(app(Inv, "f"), comp("f", "g")), comp(app(Inv, "f"), "h"))),
+            app2(Eq, comp(comp(app(Inv, "f"), "f"), "g"), comp(app(Inv, "f"), "h"))),
         // `((f . g) = h) <=> (((f . g) . inv(g)) = (h . inv(g)))`
         Eqv(app2(Eq, comp("f", "g"), "h"),
             app2(Eq, comp(comp("f", "g"), app(Inv, "g")), comp("h", app(Inv, "g")))),


### PR DESCRIPTION
Reduces number of steps since `inv(f) . f <=> id`