### PR TITLE
Fixed display of `f:!{}`

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -41,9 +41,10 @@ impl Expr {
         &self,
         w: &mut fmt::Formatter<'_>,
         parens: bool,
+        rule: bool,
     ) -> std::result::Result<(), fmt::Error> {
         match self {
-            Sym(s) => write!(w, "{}", s)?,
+            Sym(s) => s.display(w, rule)?,
             Ret(v) => write!(w, "{}", v)?,
             Op(Path, a, b) => {
                 if let Sym(b) = &**b {
@@ -152,10 +153,10 @@ impl Expr {
                         | -> std::result::Result<(), fmt::Error> {
                             if parens {write!(w, "(")?};
                             let left = true;
-                            a.display(w, a.needs_parens(op_sym, left))?;
+                            a.display(w, a.needs_parens(op_sym, left), rule)?;
                             write!(w, " {} ", op_txt)?;
                             let right = false;
-                            b.display(w, b.needs_parens(op_sym, right))?;
+                            b.display(w, b.needs_parens(op_sym, right), rule)?;
                             if parens {write!(w, ")")?};
                             Ok(())
                         };
@@ -226,7 +227,8 @@ impl Expr {
                         if let Ret(_) = **a {
                             write!(w, "\\")?;
                         }
-                        write!(w, "{}", a)?;
+                        let parens = true;
+                        a.display(w, parens, rule)?;
                     }
                     if let Tup(b) = &**b {
                         write!(w, "(")?;
@@ -327,7 +329,8 @@ impl Expr {
 impl fmt::Display for Expr {
     fn fmt(&self, w: &mut fmt::Formatter<'_>) -> std::result::Result<(), fmt::Error> {
         let parens = false;
-        self.display(w, parens)
+        let rule = false;
+        self.display(w, parens, rule)
     }
 }
 

--- a/src/knowledge.rs
+++ b/src/knowledge.rs
@@ -18,11 +18,25 @@ impl fmt::Display for Knowledge {
     fn fmt(&self, w: &mut fmt::Formatter<'_>) -> std::result::Result<(), fmt::Error> {
         use Knowledge::*;
 
+        let mut display = |op: &str, a: &Expr, b: &Expr| -> std::result::Result<(), fmt::Error> {
+            let rule = true;
+            let parens = false;
+            a.display(w, parens, rule)?;
+            write!(w, " {} ", op)?;
+            b.display(w, parens, rule)?;
+            Ok(())
+        };
         match self {
-            Def(a, b) => write!(w, "{} := {}", a, b)?,
-            Red(a, b) => write!(w, "{} => {}", a, b)?,
-            Eqv(a, b) => write!(w, "{} <=> {}", a, b)?,
-            EqvEval(a, b) => write!(w, "{} <=>> {}", a, b)?,
+            Def(a, b) => {
+                let rule = true;
+                let parens = false;
+                a.display(w, rule)?;
+                write!(w, " := ")?;
+                b.display(w, parens, rule)?;
+            }
+            Red(a, b) => display("=>", a, b)?,
+            Eqv(a, b) => display("<=>", a, b)?,
+            EqvEval(a, b) => display("<=>>", a, b)?,
         }
         Ok(())
     }

--- a/src/sym.rs
+++ b/src/sym.rs
@@ -433,8 +433,13 @@ impl From<Arc<String>> for Symbol {
     }
 }
 
-impl fmt::Display for Symbol {
-    fn fmt(&self, w: &mut fmt::Formatter<'_>) -> std::result::Result<(), fmt::Error> {
+impl Symbol {
+    /// Used to display format with additional options.
+    pub fn display(
+        &self,
+        w: &mut fmt::Formatter<'_>,
+        rule: bool,
+    ) -> std::result::Result<(), fmt::Error> {
         use Symbol::*;
 
         match self {
@@ -552,7 +557,11 @@ impl fmt::Display for Symbol {
             QuatType => write!(w, "quat")?,
             Inf => write!(w, "∞")?,
             Var(x) => write!(w, "{}", x)?,
-            NoConstrVar(x) => write!(w, "{}!{{}}", x)?,
+            NoConstrVar(x) => if rule {
+                write!(w, "{}!{{}}", x)?
+            } else {
+                write!(w, "{}", x)?
+            },
             ArityVar(x, _) => write!(w, "{}", x)?,
             RetVar(x) => write!(w, "\\{}", x)?,
             RetIntVar(x) => write!(w, "\\{}:int", x)?,
@@ -633,5 +642,12 @@ impl fmt::Display for Symbol {
             // _ => write!(w, "{:?}", self)?,
         }
         Ok(())
+    }
+}
+
+impl fmt::Display for Symbol {
+    fn fmt(&self, w: &mut fmt::Formatter<'_>) -> std::result::Result<(), fmt::Error> {
+        let rule = false;
+        self.display(w, rule)
     }
 }


### PR DESCRIPTION
The no constraint should only be displayed in rules.