### PR TITLE
Changed symbol for derivative to `deriv` and `𝐝`

### DIFF
--- a/assets/std.md
+++ b/assets/std.md
@@ -507,18 +507,18 @@ not · (> x) => (<= x);
 
 #### Derivatives
 ```poi
-d(!\x)(x) => 1;
-d(!\x)(\y) => 0;
-d(!\x)(\k * y) => k * d(x)(y);
-d(!\x)(π * y) => π * d(x)(y);
-d(!\x)(τ * y) => τ * d(x)(y);
-d(!\x)(x ^ \k) => k * x ^ (k - 1);
-d(!\x)(sin(x)) => cos(x);
-d(!\x)(cos(x)) => -sin(x);
-d(!\x)(sin(\k * x)) => k * cos(k * x);
-d(!\x)(cos(\k * x)) => -k * sin(k * x);
-d(!\x)(exp(x)) => exp(x);
-d(!\x)(exp(\k * x)) => k * exp(k * x);
+𝐝(!\x)(x) => 1;
+𝐝(!\x)(\y) => 0;
+𝐝(!\x)(\k * y) => k * 𝐝(x)(y);
+𝐝(!\x)(π * y) => π * 𝐝(x)(y);
+𝐝(!\x)(τ * y) => τ * 𝐝(x)(y);
+𝐝(!\x)(x ^ \k) => k * x ^ (k - 1);
+𝐝(!\x)(sin(x)) => cos(x);
+𝐝(!\x)(cos(x)) => -sin(x);
+𝐝(!\x)(sin(\k * x)) => k * cos(k * x);
+𝐝(!\x)(cos(\k * x)) => -k * sin(k * x);
+𝐝(!\x)(exp(x)) => exp(x);
+𝐝(!\x)(exp(\k * x)) => k * exp(k * x);
 ```
 
 #### Indefinite integrals

--- a/src/arity.rs
+++ b/src/arity.rs
@@ -19,7 +19,7 @@ impl Symbol {
             Imply | Fstb | Sndb | Lt | Rlt | Le | Rle | Gt | Rgt |
             Ge | Rge | Mulc | Pow | Rpow | Concat | Min2 | Max2 |
             MulMat | Base | Fst | Snd | Atan2 | Dot | Push | PushFront |
-            Item | Col | Neq | D | Rty | VecUop => Some(2),
+            Item | Col | Neq | Deriv | Rty | VecUop => Some(2),
 
             Range | Rangel | Ranger | Rangem | El | If | VecOp | Integ => Some(3),
 

--- a/src/sym.rs
+++ b/src/sym.rs
@@ -246,7 +246,7 @@ pub enum Symbol {
     /// Function inverse `inv`.
     Inv,
     /// Derivative.
-    D,
+    Deriv,
     /// Integral.
     Integ,
     /// `if`.
@@ -416,7 +416,7 @@ impl From<Arc<String>> for Symbol {
             "vec_op" => VecOp,
             "vec_uop" => VecUop,
             "arity" => Arity,
-            "d" => D,
+            "deriv" | "𝐝" => Deriv,
             "integ" | "∫" => Integ,
             "pi" | "π" => Pi,
             "tau" | "τ" => Tau,
@@ -544,7 +544,7 @@ impl Symbol {
             VecOp => write!(w, "vec_op")?,
             VecUop => write!(w, "vec_uop")?,
             Arity => write!(w, "arity")?,
-            D => write!(w, "d")?,
+            Deriv => write!(w, "𝐝")?,
             Integ => write!(w, "∫")?,
             Pi => write!(w, "π")?,
             Tau => write!(w, "τ")?,


### PR DESCRIPTION
Closes https://github.com/advancedresearch/poi/issues/872