### PR TITLE
Fixed `∂((x - s)^\k) / (∂ * x!>s) => k * (x - s) ^ (k - 1);`

### DIFF
--- a/assets/std.md
+++ b/assets/std.md
@@ -615,7 +615,7 @@ which is fixed by using the following notation:
 ∂(a - b) / ∂c => ∂(a) / ∂c - ∂(b) / ∂c;
 ∂(x) / ∂x => 𝐝(x)(x);
 ∂(x^\k) / ∂x => 𝐝(x)(x^k);
-∂((x - s)^\k) / (∂ * x!>s) => 𝐝(x)((x - s:\)^k);
+∂((x - s)^\k) / (∂ * x!>s) => k * (x - s) ^ (k - 1);
 ∂(a * b) / (∂ * x!>a) => a * (∂(b) / ∂x);
 ∂(x) / (∂ * y!>x) => 𝐝(y)(x:\);
 ```


### PR DESCRIPTION
The partial derivative does not treat constants as constants in the
context after taking the derivative, so it must expand directly.